### PR TITLE
Feat: mock readWorkbookById API #11

### DIFF
--- a/src/app/dummy.ts
+++ b/src/app/dummy.ts
@@ -1,0 +1,29 @@
+import { Workbook } from '@/app/types';
+
+export const Dummy_Workbooks: Workbook[] = [
+  {
+    id: '1',
+    title: '2023 기말고사',
+    description: '2023 포철고 기말고사 대비',
+    emoji: '🤓',
+    quantity: 23,
+    modifiedAt: new Date('2023-09-13'),
+  },
+  {
+    id: '2',
+    title: '2024 중간고사',
+    description: '2024 제철중 중간고사 대비',
+    emoji: '😜',
+    quantity: 15,
+    modifiedAt: new Date('2024-04-15'),
+  },
+];
+
+export const Dummy_Workbook: Workbook = {
+  id: '1',
+  title: '2023 기말고사',
+  description: '2023 포철고 기말고사 대비',
+  emoji: '🤓',
+  quantity: 23,
+  modifiedAt: new Date('2023-09-13'),
+};

--- a/src/app/endpoint.ts
+++ b/src/app/endpoint.ts
@@ -2,3 +2,4 @@ const BASE_URL = 'http://localhost:3000';
 
 export const readWorkbooksUrl: string = `${BASE_URL}/workbooks`;
 export const createWorkbookUrl: string = `${BASE_URL}/workbook`;
+export const readWorkbookByIdUrl = (id: string) => `${BASE_URL}/workbook/${id}`;

--- a/src/app/main/navigation.tsx
+++ b/src/app/main/navigation.tsx
@@ -2,6 +2,7 @@
 
 import Link from 'next/link';
 import { usePathname } from 'next/navigation';
+import { MAIN_ROUTES } from '@/app/routing';
 
 interface NavigationItem {
   path: string;
@@ -10,19 +11,19 @@ interface NavigationItem {
 
 const navigationList: NavigationItem[] = [
   {
-    path: '/main/workbook',
+    path: MAIN_ROUTES.workbook,
     buttonText: '문제집',
   },
   {
-    path: '/main/question',
+    path: MAIN_ROUTES.question,
     buttonText: '문제',
   },
   {
-    path: '/main/share',
+    path: MAIN_ROUTES.share,
     buttonText: '공유',
   },
   {
-    path: '/main/mypage',
+    path: MAIN_ROUTES.mypage,
     buttonText: '마이페이지',
   },
 ];

--- a/src/app/main/workbook/drawer.tsx
+++ b/src/app/main/workbook/drawer.tsx
@@ -5,19 +5,14 @@ import {
   DrawerClose,
   DrawerContent,
   DrawerDescription,
-  DrawerFooter,
-  DrawerHeader,
   DrawerTitle,
   DrawerTrigger,
 } from '@/components/ui/drawer';
 
 import { Label } from '@/components/ui/label';
 import { CustomTextInput } from '@/components/custom/custom-text-input';
-import React, { useState, useEffect, useCallback } from 'react';
-import {
-  createWorkbookUrl,
-  readWorkbooksUrl,
-} from '@/app/main/workbook/endpoint';
+import React, { useState } from 'react';
+import { createWorkbookUrl } from '@/app/endpoint';
 
 export function DrawerDemo() {
   const [open, setOpen] = useState<boolean>(false);

--- a/src/app/main/workbook/workbook-area.tsx
+++ b/src/app/main/workbook/workbook-area.tsx
@@ -1,9 +1,10 @@
 'use client';
 
-import WorkbookCards from '@/app/main/workbook/workbook-cards';
-import { Workbook } from '@/app/main/workbook/workbook-cards';
 import { useEffect, useState } from 'react';
 import { readWorkbooksUrl } from '@/app/main/workbook/endpoint';
+import { Workbook } from '@/app/types';
+
+import WorkbookCards from '@/app/main/workbook/workbook-cards';
 
 type Status = 'loading' | 'error' | 'success';
 

--- a/src/app/main/workbook/workbook-area.tsx
+++ b/src/app/main/workbook/workbook-area.tsx
@@ -1,12 +1,10 @@
 'use client';
 
 import { useEffect, useState } from 'react';
-import { readWorkbooksUrl } from '@/app/main/workbook/endpoint';
-import { Workbook } from '@/app/types';
+import { readWorkbooksUrl } from '@/app/endpoint';
+import { Workbook, Status } from '@/app/types';
 
 import WorkbookCards from '@/app/main/workbook/workbook-cards';
-
-type Status = 'loading' | 'error' | 'success';
 
 const WorkbookArea = () => {
   const [status, setStatus] = useState<Status>('loading');

--- a/src/app/main/workbook/workbook-cards.tsx
+++ b/src/app/main/workbook/workbook-cards.tsx
@@ -1,23 +1,20 @@
 'use client';
 
-export type Workbook = {
-  id: string;
-  title: string;
-  description: string;
-  emoji: string;
-  quantity: number;
-  modifiedAt: Date;
-};
+import { Workbook } from '@/app/types';
+import Link from 'next/link';
+import { SUB_ROUTES } from '@/app/routing';
 
 const WorkbookCard = ({ workbook }: { workbook: Workbook }) => {
   return (
-    <div className="w-4/5 p-1 border-black border-[1px]">
-      <div>{workbook.emoji}</div>
-      <div>{workbook.title}</div>
-      <div>{workbook.description}</div>
-      <div>{workbook.quantity}</div>
-      <div suppressHydrationWarning>{workbook.modifiedAt.toString()}</div>
-    </div>
+    <Link href={SUB_ROUTES.workbookDetail(workbook.id)} passHref>
+      <div className="w-4/5 p-1 border-black border-[1px]">
+        <div>{workbook.emoji}</div>
+        <div>{workbook.title}</div>
+        <div>{workbook.description}</div>
+        <div>{workbook.quantity}</div>
+        <div suppressHydrationWarning>{workbook.modifiedAt.toString()}</div>
+      </div>
+    </Link>
   );
 };
 

--- a/src/app/main/workbook/workbook.stories.tsx
+++ b/src/app/main/workbook/workbook.stories.tsx
@@ -1,13 +1,8 @@
 import type { Meta, StoryObj } from '@storybook/react';
-import { fn } from '@storybook/test';
-import { Workbook } from '@/app/types';
-
 import { http, HttpResponse, delay } from 'msw';
+import { createWorkbookUrl, readWorkbooksUrl } from '@/app/endpoint';
+import { Dummy_Workbooks } from '@/app/dummy';
 import Page from './page';
-import {
-  createWorkbookUrl,
-  readWorkbooksUrl,
-} from '@/app/main/workbook/endpoint';
 
 const meta = {
   title: 'Workbook',
@@ -26,25 +21,6 @@ const meta = {
 
 export default meta;
 type Story = StoryObj<typeof meta>;
-
-const Dummy_Workbooks: Workbook[] = [
-  {
-    id: '1',
-    title: '2023 기말고사',
-    description: '2023 포철고 기말고사 대비',
-    emoji: '🤓',
-    quantity: 23,
-    modifiedAt: new Date('2023-09-13'),
-  },
-  {
-    id: '2',
-    title: '2024 중간고사',
-    description: '2024 제철중 중간고사 대비',
-    emoji: '😜',
-    quantity: 15,
-    modifiedAt: new Date('2024-04-15'),
-  },
-];
 
 export const Success: Story = {
   parameters: {

--- a/src/app/main/workbook/workbook.stories.tsx
+++ b/src/app/main/workbook/workbook.stories.tsx
@@ -1,6 +1,6 @@
 import type { Meta, StoryObj } from '@storybook/react';
 import { fn } from '@storybook/test';
-import { Workbook } from '@/app/main/workbook/workbook-cards';
+import { Workbook } from '@/app/types';
 
 import { http, HttpResponse, delay } from 'msw';
 import Page from './page';

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,12 +1,13 @@
 'use client';
 
 import { useRouter } from 'next/navigation';
+import { MAIN_ROUTES } from '@/app/routing';
 
 const Authenticate = () => {
   const isUser: boolean = true;
   const router = useRouter();
 
-  if (isUser) router.push('/main/workbook');
+  if (isUser) router.push(MAIN_ROUTES.workbook);
   else router.push('/signinup');
 };
 

--- a/src/app/routing.ts
+++ b/src/app/routing.ts
@@ -1,0 +1,14 @@
+const MAIN_BASE: string = '/main';
+
+export const MAIN_ROUTES = {
+  workbook: MAIN_BASE + '/workbook',
+  question: MAIN_BASE + '/question',
+  share: MAIN_BASE + '/share',
+  mypage: MAIN_BASE + '/mypage',
+};
+
+const SUB_BASE: string = '/sub';
+
+export const SUB_ROUTES = {
+  workbookDetail: (id: string): string => `${SUB_BASE}/workbookDetail/${id}`,
+};

--- a/src/app/sub/workbookDetail/[workbookId]/header.tsx
+++ b/src/app/sub/workbookDetail/[workbookId]/header.tsx
@@ -1,9 +1,17 @@
+'use client';
 import React from 'react';
+import { useRouter } from 'next/navigation';
 
 const Header = () => {
+  const router = useRouter();
+
+  const handleBackClick: React.MouseEventHandler<HTMLButtonElement> = () => {
+    router.back();
+  };
+
   return (
     <div className="flex flex-row">
-      <button>go back</button>
+      <button onClick={handleBackClick}>go back</button>
       <h1>문제집 상세</h1>
     </div>
   );

--- a/src/app/sub/workbookDetail/[workbookId]/header.tsx
+++ b/src/app/sub/workbookDetail/[workbookId]/header.tsx
@@ -1,0 +1,12 @@
+import React from 'react';
+
+const Header = () => {
+  return (
+    <div className="flex flex-row">
+      <button>go back</button>
+      <h1>문제집 상세</h1>
+    </div>
+  );
+};
+
+export default Header;

--- a/src/app/sub/workbookDetail/[workbookId]/page.tsx
+++ b/src/app/sub/workbookDetail/[workbookId]/page.tsx
@@ -1,0 +1,22 @@
+'use client';
+
+import { useParams } from 'next/navigation';
+import Header from '@/app/sub/workbookDetail/[workbookId]/header';
+import WorkbookInformation from '@/app/sub/workbookDetail/[workbookId]/workbook-information';
+import WorkbookEditButtons from '@/app/sub/workbookDetail/[workbookId]/workbook-edit-buttons';
+import WorkbookQuestions from '@/app/sub/workbookDetail/[workbookId]/workbook-questions';
+
+const Page = () => {
+  const params = useParams<{ workbookId: string }>();
+
+  return (
+    <div>
+      <Header />
+      <WorkbookInformation />
+      <WorkbookEditButtons />
+      <WorkbookQuestions />
+    </div>
+  );
+};
+
+export default Page;

--- a/src/app/sub/workbookDetail/[workbookId]/workbook-edit-buttons.tsx
+++ b/src/app/sub/workbookDetail/[workbookId]/workbook-edit-buttons.tsx
@@ -1,0 +1,11 @@
+const WorkbookEditButtons = () => {
+  return (
+    <div>
+      <button>문제집 편집</button>
+      <button>문제집 삭제</button>
+      <button>문제집 공유</button>
+    </div>
+  );
+};
+
+export default WorkbookEditButtons;

--- a/src/app/sub/workbookDetail/[workbookId]/workbook-information.tsx
+++ b/src/app/sub/workbookDetail/[workbookId]/workbook-information.tsx
@@ -1,0 +1,47 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { Status, Workbook } from '@/app/types';
+import { useParams, usePathname } from 'next/navigation';
+import { readWorkbookByIdUrl } from '@/app/endpoint';
+
+const WorkbookInformation = () => {
+  const [workbook, setWorkbook] = useState<Workbook | null>(null);
+  const [status, setStatus] = useState<Status>('loading');
+
+  const params = useParams<{ workbookId: string }>();
+  const pathname = usePathname();
+
+  useEffect(() => {
+    fetch(readWorkbookByIdUrl(params.workbookId))
+      .then((res) => res.json())
+      .then((res) => {
+        setWorkbook(res);
+        setStatus('success');
+      })
+      .catch((err) => {
+        console.error(err);
+        setStatus('error');
+      });
+  }, []);
+
+  if (status === 'loading') return <div>loading..</div>;
+  else if (status === 'error') return <div>workbook-information load fail</div>;
+  else
+    return (
+      <div>
+        <div className="flex flew-row">
+          <div>{workbook?.emoji}</div>
+          <div>문제수 : {workbook?.quantity}</div>
+          <div>공유 : 0</div>
+          <div>수정일 : {workbook?.modifiedAt.toString()}</div>
+        </div>
+        <div className="flex flew-row">
+          <div>{workbook?.title}</div>
+          <div>{workbook?.description}</div>
+        </div>
+      </div>
+    );
+};
+
+export default WorkbookInformation;

--- a/src/app/sub/workbookDetail/[workbookId]/workbook-questions.tsx
+++ b/src/app/sub/workbookDetail/[workbookId]/workbook-questions.tsx
@@ -1,0 +1,5 @@
+const WorkbookQuestions = () => {
+  return <div>Question in workbook</div>;
+};
+
+export default WorkbookQuestions;

--- a/src/app/sub/workbookDetail/[workbookId]/workbookDetail.stories.tsx
+++ b/src/app/sub/workbookDetail/[workbookId]/workbookDetail.stories.tsx
@@ -1,0 +1,57 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { http, HttpResponse, delay } from 'msw';
+import { readWorkbookByIdUrl } from '@/app/endpoint';
+import { Dummy_Workbook } from '@/app/dummy';
+
+import Page from './page';
+
+const meta = {
+  title: 'WorkbookDetail',
+  component: Page,
+  decorators: [
+    (Story) => (
+      <div className="w-[430px] h-[932px] bg-white relative">
+        <Story />
+      </div>
+    ),
+  ],
+  parameters: {
+    layout: 'centered',
+    nextjs: {
+      appDirectory: true,
+      navigation: {
+        segments: [['workbookId', '1']],
+      },
+    },
+  },
+} satisfies Meta<typeof Page>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Success: Story = {
+  parameters: {
+    msw: {
+      handlers: [
+        http.get(readWorkbookByIdUrl('1'), () => {
+          return HttpResponse.json(Dummy_Workbook);
+        }),
+      ],
+    },
+  },
+};
+
+export const FailReadingWorkbookById: Story = {
+  parameters: {
+    msw: {
+      handlers: [
+        http.get(readWorkbookByIdUrl('1'), async () => {
+          await delay(1000);
+          return new HttpResponse(null, {
+            status: 403,
+          });
+        }),
+      ],
+    },
+  },
+};

--- a/src/app/types.ts
+++ b/src/app/types.ts
@@ -1,0 +1,8 @@
+export type Workbook = {
+  id: string;
+  title: string;
+  description: string;
+  emoji: string;
+  quantity: number;
+  modifiedAt: Date;
+};

--- a/src/app/types.ts
+++ b/src/app/types.ts
@@ -6,3 +6,20 @@ export type Workbook = {
   quantity: number;
   modifiedAt: Date;
 };
+
+export type Question = {
+  id: string;
+  status: string;
+  options: string;
+  image: string;
+  answer: string;
+  category: string;
+  tags: string[];
+  modifiedAt: Date;
+};
+
+export type QuestionInWorkbook = {
+  sequence: number;
+} & Question;
+
+export type Status = 'loading' | 'error' | 'success';


### PR DESCRIPTION
### 🤔 Description
* 문제집 상세 페이지에 대한 간단한 UI를 구현하고 `readWorkBookById` API mock과 그에 따른 storybook을 구현한다.

### 👋 Related issues
* **Close** #11 

### 🔍 Details
* 현재 문제집 정보 관련 data fetch와 만을 구현한 상태이다. 최초에 문제집 정보와 문제집 내의 문제들을 한번에 주던 API를 두 개의 API로 분리해달라고 BE에 요청했다. 이유는, 해당 화면에서 data fetch 실패 시 부분적으로 오류 화면을 띄워줄 예정이고, parrellel하게 data fetch 역시 UX적으로 낫다고 생각하기 때문이다.

<p align="center">
<img width="442" alt="스크린샷 2024-07-14 오후 11 03 55" src="https://github.com/user-attachments/assets/4705e22d-cdf7-410e-b711-f5a73e1cfb65">
.)</p>

* 추가로 위의 화면에서 go back을 누루게 되면 이전 화면으로 이동하게 된다. 해당 UI는 `app/workbookDetail/[workbookID]/header.tsx`에 존재하며 높은 확률로 후에 공통 컴포넌트로 옮기게 될 것 같다. 그 경우 "문제집 상세"와 같이 어떤 화면인지를 나타내는 제목을 prop으로 받아야 할 것 같다.

### 🐛 Bugs
* 🤷‍♂️ 버그는 없는데 긴가민가 한게 너무 많다

### 💬 Others
* 현재 문제집 조회 페이지에서 각 문제집을 누르면 해당 문제집에 대한 상세페이지로 이동하게 된다. 그러나 이를 확인하고 싶어도 storybook에서 페이지 이동 (혹은 스토리 간의 이동)을 제공하지는 않는 것 같아서 테스팅이 참 애매하다.

* 또한 문제집 상세에 대한 storybook에서 path parameter를 확보하기 위해

  ```typescript
  // workbookDetail.stories.tsx
  nextjs: {
     appDirectory: true,
     navigation: {
       segments: [['workbookId', '1']],
     },
  },
  ```
  와 같이 path parameter에 고정된 값인 `1`을 주고 있는데, 이 역시 뭔가 동적으로 바꿀 수 없어 완벽하게 페이지 라우팅과 data fetching을 테스트하기 어렵다.. 😞

* 마지막으로 현재 app내에서 `endpoint.ts`, `dummy.ts`, `routing.ts`을 한번에 관리하고 있는데 좀 이상한 폴더구조인가..?
