### PR TITLE
Refactor: refactor input with x button component for higher reusability

### DIFF
--- a/src/app/main/workbook/drawer-refactor.tsx
+++ b/src/app/main/workbook/drawer-refactor.tsx
@@ -1,0 +1,76 @@
+'use client';
+
+import {
+  Drawer,
+  DrawerClose,
+  DrawerContent,
+  DrawerDescription,
+  DrawerTitle,
+  DrawerTrigger,
+} from '@/components/ui/drawer';
+
+import { Label } from '@/components/ui/label';
+import { TextInput } from '@/components/custom/text-input';
+import React, { useRef, useState } from 'react';
+import { createWorkbookUrl } from '@/app/endpoint';
+
+function DrawerRefactor() {
+  const [open, setOpen] = useState<boolean>(false);
+  const [response, setResponse] = useState<string>('');
+  const titleRef = useRef<HTMLInputElement>(null);
+  const descriptionRef = useRef<HTMLInputElement>(null);
+
+  const handleToggleClick: React.MouseEventHandler<HTMLButtonElement> = () => {
+    setOpen(!open);
+  };
+
+  const handleFormSubmit: React.FormEventHandler<HTMLFormElement> = async (
+    e,
+  ) => {
+    e.preventDefault();
+
+    try {
+      const res = await fetch(createWorkbookUrl, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({
+          title: titleRef.current?.value,
+          description: descriptionRef.current?.value,
+        }),
+      });
+
+      const data = await res.json();
+      setResponse('성공');
+      setOpen(false);
+    } catch (e) {
+      setResponse('실패!');
+      console.error('createWorkbook failed');
+    }
+  };
+
+  return (
+    <Drawer open={open}>
+      <DrawerTrigger asChild onClick={handleToggleClick}>
+        <button>Open Drawer</button>
+      </DrawerTrigger>
+
+      <DrawerContent className="bg-white">
+        <DrawerTitle>문제집 생성</DrawerTitle>
+        <DrawerDescription />
+        <DrawerClose onClick={handleToggleClick}>취소</DrawerClose>
+        {response}
+        <form onSubmit={handleFormSubmit}>
+          <Label htmlFor="title">문제집 제목</Label>
+          <TextInput id="title" allowClear ref={titleRef} />
+          <Label htmlFor="description">문제집 설명</Label>
+          <TextInput id="description" allowClear ref={descriptionRef} />
+          <button>확인</button>
+        </form>
+      </DrawerContent>
+    </Drawer>
+  );
+}
+
+export default DrawerRefactor;

--- a/src/app/main/workbook/page.tsx
+++ b/src/app/main/workbook/page.tsx
@@ -2,13 +2,15 @@
 
 import WorkbookArea from '@/app/main/workbook/workbook-area';
 import { DrawerDemo } from '@/app/main/workbook/drawer';
+import DrawerRefactor from '@/app/main/workbook/drawer-refactor';
 
 const Page = () => {
   return (
     <div className="w-full h-full bg-white">
       <h1>문제집 관리</h1>
       <WorkbookArea />
-      <DrawerDemo />
+      {/*<DrawerDemo />*/}
+      <DrawerRefactor />
     </div>
   );
 };

--- a/src/components/custom/text-input.tsx
+++ b/src/components/custom/text-input.tsx
@@ -1,0 +1,46 @@
+import React, { useState } from 'react';
+import { cn } from '@/lib/utils';
+
+type TextInputProps = React.InputHTMLAttributes<HTMLInputElement> & {
+  allowClear?: boolean;
+};
+
+const TextInput = React.forwardRef<HTMLInputElement, TextInputProps>(
+  ({ className, allowClear = false, ...props }, ref) => {
+    const [inputValue, setInputValue] = useState<string>('');
+
+    const handleInputChange: React.ChangeEventHandler<HTMLInputElement> = (
+      e,
+    ) => {
+      setInputValue(e.target.value);
+    };
+
+    const handleClearClick: React.MouseEventHandler<HTMLButtonElement> = () => {
+      setInputValue('');
+    };
+
+    return (
+      <div className="flex p-4">
+        <input
+          type="text"
+          value={inputValue}
+          onChange={handleInputChange}
+          className={cn(
+            'flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background file:border-0 file:bg-transparent file:text-sm file:font-medium placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50',
+            className,
+          )}
+          ref={ref}
+          {...props}
+        />
+        {allowClear && (
+          <button type="button" onClick={handleClearClick}>
+            X
+          </button>
+        )}
+      </div>
+    );
+  },
+);
+TextInput.displayName = 'TextInput';
+
+export { TextInput };


### PR DESCRIPTION
### 🤔 Description
* 기존의 입력창과 입력 제거 버튼이 함께 있는 UI component인 `custom-text-input.tsx`의 리팩토링을 진행한다.

* 기존 컴포넌트의 경우 state, state setter function, event handler를 모두 주입받았다면, 리팩토링한 컴포넌트의 경우 부모 컴포넌트에서 `ref`를 통해 input의 value에 접근할 수 있게 하여 더 재사용성 높고 간결한 코드를 생성하고자 했다. 🤓

### 👋 Related issues
* **Close** #15 

### 🔍 Details

 ```typescript
// text-input.tsx

type TextInputProps = React.InputHTMLAttributes<HTMLInputElement> & {
  allowClear?: boolean;
};

const TextInput = React.forwardRef<HTMLInputElement, TextInputProps>(
  ({ className, allowClear = false, ...props }, ref) => {
```

* 부모 컴포넌트에서 input에 `ref`로 접근해야하기에 [forwardRef](https://react.dev/reference/react/forwardRef)를 사용했다.
* 또한 [Ant Design의 input](https://ant.design/components/input)과 같이 `allowClear`라는 prop을 통해 입력 내용 삭제 버튼을 활성화 시킬지 결정한다.

* 추가적으로, 기존에 api 호출이 `<form>`의 `onSubmit` handler로 구현이 되어있어서 입력 내용 삭제 버튼을 눌러도 `createWorkbook` API 호출이 발생하고 있었다. 따라서 `<button type="button"/>`를 통해 잘못된 API 호출을 막았다.

### 🐛 Bugs
* 사실 이전에 버그가 있었던 거였음..😱

### 💬 Others

* 현재 `text-input.tsx` 내부에서는 state를 통해 input의 value가 관리되고 있다. 그러나 부모 컴포넌트 입장에서는 어처피 `ref`를 이용하고, 입력 내용 삭제 버튼은 `<input type="reset"/>`을 이용하여 구현할 수 있으므로 굳이 input의 value로 state를 이용할 필요는 없다.

   그러나! 후에 입력의 길이 혹은 특수문자 사용 여부 등의 제한 사항이 발생할 경우 state를 활용하는 것이 훨씬 편할 것이라 판단하여 state로 input의 value를 구현했다. 😾

* 또한 현재 storybook을 통한 구현한 API success story에서 API 호출의 endpoint만 맞다면 문제가 발생하지 않는데, API 호출 시 body가 올바른지 확인하는 로직도 storybook에 추가되어야 할 것 같다.