### PR TITLE
Feat: mock readQuestionsInWorkbook API

### DIFF
--- a/src/app/dummy.ts
+++ b/src/app/dummy.ts
@@ -1,4 +1,4 @@
-import { Workbook } from '@/app/types';
+import { Workbook, QuestionInWorkbook } from '@/app/types';
 
 export const Dummy_Workbooks: Workbook[] = [
   {
@@ -27,3 +27,26 @@ export const Dummy_Workbook: Workbook = {
   quantity: 23,
   modifiedAt: new Date('2023-09-13'),
 };
+
+export const Dummy_Questions_In_Workbook: QuestionInWorkbook[] = [
+  {
+    id: '0',
+    statement: '이 문제는 어디서부터 건너왔으며 어디서 나온다.',
+    options: ['원', '삼각형', '직사각형', '오각형'],
+    image: '이상한 url',
+    answer: '4',
+    category: '객관식',
+    tags: ['미적분II', '3번틀린문제'],
+    sequence: 1,
+  },
+  {
+    id: '1',
+    statement: 'cos + sin은 35도일 때 이를 위한 구성요소를 구하시오',
+    options: ['30', '45', '60', '90'],
+    image: '이상한 url',
+    answer: '1',
+    category: '객관식',
+    tags: ['수학II', '이건태그얌'],
+    sequence: 2,
+  },
+];

--- a/src/app/endpoint.ts
+++ b/src/app/endpoint.ts
@@ -1,6 +1,10 @@
-const BASE_URL = 'http://localhost:3000';
+const BASE_URL = 'http://localhost:3000/api';
 
 export const readWorkbooksUrl: string = `${BASE_URL}/workbooks`;
 export const createWorkbookUrl: string = `${BASE_URL}/workbook`;
+
 export const readWorkbookByIdUrl = (id: string) => `${BASE_URL}/workbook/${id}`;
 export const deleteWorkbookByIdUrl = (id: string) => readWorkbookByIdUrl(id);
+
+export const readQuestionInWorkbook = (id: string) =>
+  `${BASE_URL}/workbook/questions/${id}`;

--- a/src/app/sub/workbookDetail/[workbookId]/question-card.tsx
+++ b/src/app/sub/workbookDetail/[workbookId]/question-card.tsx
@@ -1,0 +1,53 @@
+import React, { useState } from 'react';
+import { QuestionInWorkbook } from '@/app/types';
+
+const QuestionCard = ({ question }: { question: QuestionInWorkbook }) => {
+  const [isExpanded, setExpanded] = useState<boolean>(false);
+
+  const handleExpandToggleClick: React.MouseEventHandler<
+    HTMLButtonElement
+  > = () => {
+    setExpanded((prev) => !prev);
+  };
+
+  if (!isExpanded) {
+    return (
+      <div className="flex p-4 border-[1px]">
+        <button onClick={handleExpandToggleClick}>▶️</button>
+        <p>{`Q${question.sequence}`}</p>
+        <p>{question.category}</p>
+        {question.tags.map((tag, idx) => (
+          <p key={idx}>{tag}</p>
+        ))}
+        <p>{question.statement}</p>
+        <button>=</button>
+      </div>
+    );
+  } else {
+    return (
+      <div className="flex flex-col p-4 border-[1px]">
+        <div className="flex">
+          <button onClick={handleExpandToggleClick}>🔽</button>
+          <p>{`Q${question.sequence}`}</p>
+          <p>{question.category}</p>
+          {question.tags.map((tag, idx) => (
+            <p key={idx}>{tag}</p>
+          ))}
+          <p>{question.statement}</p>
+          <button>ℹ️</button>
+        </div>
+        <img src={question.image} alt="사진 로드 실패" />
+        <div>문제 설명</div>
+        <p>{question.statement}</p>
+        <div>선택지</div>
+        <div className="flex">
+          {question.options.map((option, idx) => (
+            <p key={idx}>{`${idx + 1} ${option}`}</p>
+          ))}
+        </div>
+      </div>
+    );
+  }
+};
+
+export default QuestionCard;

--- a/src/app/sub/workbookDetail/[workbookId]/workbook-questions.tsx
+++ b/src/app/sub/workbookDetail/[workbookId]/workbook-questions.tsx
@@ -1,5 +1,33 @@
+import QuestionCard from '@/app/sub/workbookDetail/[workbookId]/question-card';
+import { useEffect, useState } from 'react';
+import { QuestionInWorkbook, Status } from '@/app/types';
+import { readQuestionInWorkbook } from '@/app/endpoint';
+import { useParams } from 'next/navigation';
+
 const WorkbookQuestions = () => {
-  return <div>Question in workbook</div>;
+  const [status, setStatus] = useState<Status>('loading');
+  const [questions, setQuestions] = useState<QuestionInWorkbook[]>([]);
+  const params = useParams<{ workbookId: string }>();
+
+  useEffect(() => {
+    fetch(readQuestionInWorkbook(params.workbookId))
+      .then((res) => res.json())
+      .then((res) => {
+        setQuestions(res);
+        setStatus('success');
+      })
+      .catch((err) => setStatus('error'));
+  }, []);
+
+  if (status === 'loading') return <div>loading..</div>;
+  else if (status === 'error') return <div>Question Data fetch Error</div>;
+  return (
+    <div className="flex flex-col gap-4 p-4">
+      {questions.map((ques) => (
+        <QuestionCard key={ques.id} question={ques} />
+      ))}
+    </div>
+  );
 };
 
 export default WorkbookQuestions;

--- a/src/app/sub/workbookDetail/[workbookId]/workbookDetail.stories.tsx
+++ b/src/app/sub/workbookDetail/[workbookId]/workbookDetail.stories.tsx
@@ -1,7 +1,11 @@
 import type { Meta, StoryObj } from '@storybook/react';
 import { http, HttpResponse, delay } from 'msw';
-import { deleteWorkbookByIdUrl, readWorkbookByIdUrl } from '@/app/endpoint';
-import { Dummy_Workbook } from '@/app/dummy';
+import {
+  deleteWorkbookByIdUrl,
+  readQuestionInWorkbook,
+  readWorkbookByIdUrl,
+} from '@/app/endpoint';
+import { Dummy_Questions_In_Workbook, Dummy_Workbook } from '@/app/dummy';
 
 import Page from './page';
 
@@ -36,6 +40,9 @@ export const Success: Story = {
         http.get(readWorkbookByIdUrl('1'), () => {
           return HttpResponse.json(Dummy_Workbook);
         }),
+        http.get(readQuestionInWorkbook('1'), () => {
+          return HttpResponse.json(Dummy_Questions_In_Workbook);
+        }),
         http.delete(deleteWorkbookByIdUrl('1'), () => {
           return HttpResponse.json({
             result: 'SUCCESS',
@@ -47,11 +54,17 @@ export const Success: Story = {
   },
 };
 
-export const FailReadingWorkbookById: Story = {
+export const FailReadingWorkbookAndQuestion: Story = {
   parameters: {
     msw: {
       handlers: [
         http.get(readWorkbookByIdUrl('1'), async () => {
+          await delay(1000);
+          return new HttpResponse(null, {
+            status: 403,
+          });
+        }),
+        http.get(readQuestionInWorkbook('1'), async () => {
           await delay(1000);
           return new HttpResponse(null, {
             status: 403,

--- a/src/app/types.ts
+++ b/src/app/types.ts
@@ -9,8 +9,11 @@ export type Workbook = {
 
 export type Question = {
   id: string;
-  status: string;
-  options: string;
+  statement: string;
+  // options: {
+  //   [key: string]: string;
+  // };
+  options: string[];
   image: string;
   answer: string;
   category: string;


### PR DESCRIPTION
### 🤔 Description
* `readQuestionsInWorkbook` API mock 및 관련된 UI의 구현을 진행한다. 문제 펼쳐보기의 경우 따로 `shadcn/ui`를 사용하지는 않았다.

### 👋 Related issues
* **Close** #17 

### 🔍 Details
* 문제집 내의 문제들에 대한 간략한 UI를 구현했다. 아래 사진을 기준으로 위쪽이 펼쳐진 상태, 아래쪽이 닫혀진 상태이며 `isExpanded` state로 관리된다.

<p align="center">
<img src="https://github.com/user-attachments/assets/2ed459e8-4ea4-4398-a85c-c2aed039a74a"/>
</p>

* API mocking 실패 story의 경우, 기존 문제집 정보를 불러오지 못하는 시나리오와 함께 구성했다.

  ```typescript
  export const FailReadingWorkbookAndQuestion: Story = {
    parameters: {
      msw: {
        handlers: [
          http.get(readWorkbookByIdUrl('1'), async () => {
            await delay(1000);
            return new HttpResponse(null, {
              status: 403,
            });
          }),
          http.get(readQuestionInWorkbook('1'), async () => {
            await delay(1000);
            return new HttpResponse(null, {
              status: 403,
            });
          }),
        ],
      },
    },
  };
  ```

### 🐛 Bugs
* 우선 발견된 것은 없습니다 😀

### 💬 Others
* 점점 mocking과 api 호출이 복붙의 향연이 되고 있다...🤬
  특히 client component에서 data fetch시 반복되는 코드가 너무 많이 발생하고 있다. 무언가 대책이 필요한 듯 하다.
